### PR TITLE
generate audio tags for Opus files

### DIFF
--- a/file-server.js
+++ b/file-server.js
@@ -442,6 +442,8 @@ function serveListing(req,res,next) {
                   case 'mp3':
                     html+=`<span class="main"><audio controls width="256"><source src="${pathUrl}" type="audio/mpeg"></audio><div><a href="${pathUrl}">${file.name}</a></div></span>`;
                     break;
+                  case 'opus':
+                    ext="ogg; codecs=opus";
                   case 'wav':
                   case 'ogg':
                   case 'flac':


### PR DESCRIPTION
The media type `audio/ogg; codecs=opus` seems to be the preferred/pedantic way to specify this.
Renders and acts fine in gecko and chromium.

In the `<video>` section a few lines down, `m4v` overrides the extension in a similar way, but `m4a` and `mp3` in the `<audio>` section duplicate the majority of the tag string.
I went with the former since we can get away with it.

Each of these special cases could probably be eliminated by splitting the `switch` into 2. Doing something like asserting the mime type and subtype in 1 switch on the extension, then switching off the type to select which tag template to use.
(But I didn't do that because Good Enough™)