### PR TITLE
Add argument parser and utilize it for netif:port

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node-zopfli-es": "^1.0.6",
     "sharp": "^0.23.1",
     "shrink-ray-current": "^4.1.2",
+    "yargs": "^17.3.1",
     "yazl": "^2.5.1"
   }
 }


### PR DESCRIPTION
Allows the server interface and port be set from the CLI.
```
node .\file-server.js --help
Options:
      --version  Show version number                                   [boolean]
  -b, --bindif   Interface used by the server      [string] [default: "0.0.0.0"]
  -p, --port     Port used by the server                        [default: 12001]
  -h, --help     Show help                                             [boolean]
```

I only picked `yargs` because it was the first thing I found, if there's a better lib to use, let me know and I can swap for it.
Otherwise this is probably sane enough, but check it anyway since I don't know JS.
WorksOnMyMachine™: ✔️ 