### PR TITLE
Feat/key check

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node-zopfli-es": "^1.0.6",
     "sharp": "^0.23.1",
     "shrink-ray-current": "^4.1.2",
+    "yargs": "^17.3.1",
     "yazl": "^2.5.1"
   }
 }


### PR DESCRIPTION
Depends on: https://github.com/1000TurquoisePogs/silly-file-server/pull/10

Adds these options
```
-k, --key      HTTPS key file path           [string] [default: "./https.key"]
-c, --cert     HTTPS certificate file path  [string] [default: "./https.cert"]
```

and checks to make sure the SSL files exist. If not, use HTTP.

Aside:
I also wanted to make it so that going to `http://silly-server` would redirect to `https://sily-server` because it seems to cause trouble when you're hosting on HTTPS but try to access over HTTP.
I'm not familiar enough with express to do that so I left it alone.

Probably works: ✔️ 